### PR TITLE
feat: add shortcut to enable laptop display

### DIFF
--- a/roles/sway/files/config.d/keys
+++ b/roles/sway/files/config.d/keys
@@ -180,6 +180,9 @@ bindsym XF86AudioPause exec playerctl pause
 bindsym XF86AudioNext exec playerctl next
 bindsym XF86AudioPrev exec playerctl previous
 
+# Laptop screen config
+bindsym XF86Display output eDP-1 enable
+
 # Lock screen shortcut
 bindsym $mod+BackSpace exec  $swaylock
 


### PR DESCRIPTION
This shortcut is usefull when kanshi is not working properly and the display cables were removed with the laptop display shutted down